### PR TITLE
feat: GET /api/users/current (session token)

### DIFF
--- a/src/routes/users-route.ts
+++ b/src/routes/users-route.ts
@@ -3,7 +3,7 @@ import { jwt } from "@elysiajs/jwt";
 import { eq } from "drizzle-orm";
 import { db } from "../db";
 import { users } from "../db/schema";
-import { loginUser, registerUser } from "../services/users-service";
+import { getCurrentUser, loginUser, registerUser } from "../services/users-service";
 
 const JWT_SECRET = process.env.JWT_SECRET || "secret";
 
@@ -30,6 +30,21 @@ const publicUserRoutes = new Elysia({ prefix: "/api/users" })
         return { message: err.message };
       }
       throw e;
+    }
+  })
+  .get("/current", async ({ headers, set }) => {
+    const auth = headers["authorization"];
+    if (!auth?.startsWith("Bearer ")) {
+      set.status = 401;
+      return { error: "Unauthorized" };
+    }
+    try {
+      const token = auth.slice(7);
+      const data = await getCurrentUser(token);
+      return { data };
+    } catch {
+      set.status = 401;
+      return { error: "Unauthorized" };
     }
   });
 

--- a/src/services/users-service.ts
+++ b/src/services/users-service.ts
@@ -4,6 +4,37 @@ import { sessions, users } from "../db/schema";
 
 const LOGIN_ERROR = "Email atau password salah";
 
+export type CurrentUserPayload = {
+  id: number;
+  name: string;
+  email: string;
+  created_at: string;
+};
+
+export async function getCurrentUser(token: string): Promise<CurrentUserPayload> {
+  const sessionRows = await db.select().from(sessions).where(eq(sessions.token, token)).limit(1);
+  if (sessionRows.length === 0) {
+    throw new Error("Unauthorized");
+  }
+
+  const userId = sessionRows[0].userId;
+  const userRows = await db.select().from(users).where(eq(users.id, userId)).limit(1);
+  if (userRows.length === 0) {
+    throw new Error("Unauthorized");
+  }
+
+  const u = userRows[0];
+  const created = u.createdAt;
+  const created_at = created instanceof Date ? created.toISOString() : String(created);
+
+  return {
+    id: u.id,
+    name: u.name,
+    email: u.email,
+    created_at,
+  };
+}
+
 export async function loginUser(email: string, password: string): Promise<string> {
   const result = await db.select().from(users).where(eq(users.email, email)).limit(1);
 


### PR DESCRIPTION
## Summary

- `GET /api/users/current` — token sesi UUID lewat header `Authorization: Bearer <token>`
- `getCurrentUser` di `users-service`: lookup `sessions` lalu `users`
- Response sukses: `{ "data": { id, name, email, "created_at": "<ISO>" } }`
- Response gagal: 401 `{ "error": "Unauthorized" }`

## Closes

Closes #6
