### PR TITLE
feat(users): API logout (DELETE /api/users/logout)

### DIFF
--- a/drizzle/0000_fine_owl.sql
+++ b/drizzle/0000_fine_owl.sql
@@ -1,0 +1,9 @@
+CREATE TABLE `users` (
+	`id` serial AUTO_INCREMENT NOT NULL,
+	`name` varchar(255) NOT NULL,
+	`email` varchar(255) NOT NULL,
+	`password` varchar(255) NOT NULL,
+	`created_at` timestamp NOT NULL DEFAULT (now()),
+	CONSTRAINT `users_id` PRIMARY KEY(`id`),
+	CONSTRAINT `users_email_unique` UNIQUE(`email`)
+);

--- a/drizzle/0001_puzzling_daimon_hellstrom.sql
+++ b/drizzle/0001_puzzling_daimon_hellstrom.sql
@@ -1,0 +1,9 @@
+CREATE TABLE `sessions` (
+	`id` int AUTO_INCREMENT NOT NULL,
+	`token` varchar(255) NOT NULL,
+	`user_id` bigint unsigned NOT NULL,
+	`created_at` timestamp NOT NULL DEFAULT (now()),
+	CONSTRAINT `sessions_id` PRIMARY KEY(`id`)
+);
+--> statement-breakpoint
+ALTER TABLE `sessions` ADD CONSTRAINT `sessions_user_id_users_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON DELETE cascade ON UPDATE no action;

--- a/drizzle/0002_big_sentinel.sql
+++ b/drizzle/0002_big_sentinel.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `sessions` ADD CONSTRAINT `sessions_token_unique` UNIQUE(`token`);

--- a/drizzle/meta/0000_snapshot.json
+++ b/drizzle/meta/0000_snapshot.json
@@ -1,0 +1,78 @@
+{
+  "version": "5",
+  "dialect": "mysql",
+  "id": "1f8f280c-0d79-46e8-b13e-61939bfbf471",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "tables": {
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "users_id": {
+          "name": "users_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    }
+  },
+  "views": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "tables": {},
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/0001_snapshot.json
+++ b/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,138 @@
+{
+  "version": "5",
+  "dialect": "mysql",
+  "id": "2761885e-48c4-4ce1-aae3-1850aa00a147",
+  "prevId": "1f8f280c-0d79-46e8-b13e-61939bfbf471",
+  "tables": {
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "bigint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "sessions_id": {
+          "name": "sessions_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "users_id": {
+          "name": "users_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    }
+  },
+  "views": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "tables": {},
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/0002_snapshot.json
+++ b/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,145 @@
+{
+  "version": "5",
+  "dialect": "mysql",
+  "id": "35b9d049-1ce7-48d0-81a9-53719eab0a0a",
+  "prevId": "2761885e-48c4-4ce1-aae3-1850aa00a147",
+  "tables": {
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "bigint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "sessions_id": {
+          "name": "sessions_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "users_id": {
+          "name": "users_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    }
+  },
+  "views": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "tables": {},
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -1,0 +1,27 @@
+{
+  "version": "7",
+  "dialect": "mysql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "5",
+      "when": 1776932628827,
+      "tag": "0000_fine_owl",
+      "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "5",
+      "when": 1776935579662,
+      "tag": "0001_puzzling_daimon_hellstrom",
+      "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "5",
+      "when": 1777005554281,
+      "tag": "0002_big_sentinel",
+      "breakpoints": true
+    }
+  ]
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -10,7 +10,7 @@ export const users = mysqlTable("users", {
 
 export const sessions = mysqlTable("sessions", {
   id: int("id").autoincrement().primaryKey(),
-  token: varchar("token", { length: 255 }).notNull(),
+  token: varchar("token", { length: 255 }).notNull().unique(),
   userId: bigint("user_id", { mode: "number", unsigned: true })
     .notNull()
     .references(() => users.id, { onDelete: "cascade" }),

--- a/src/plugins/session-token-auth.ts
+++ b/src/plugins/session-token-auth.ts
@@ -1,0 +1,24 @@
+import { Elysia } from "elysia";
+
+/**
+ * Parses `Authorization: Bearer <session token>` for routes that use DB session tokens (not JWT).
+ * Invalid or missing header short-circuits with 401 and `{ error: "Unauthorized" }`.
+ */
+export const sessionTokenAuth = new Elysia({ name: "session-token-auth" })
+  .derive(({ headers }) => {
+    const auth = headers["authorization"];
+    if (!auth?.startsWith("Bearer ")) {
+      return { sessionToken: null as string | null };
+    }
+    const token = auth.slice(7).trim();
+    if (!token) {
+      return { sessionToken: null as string | null };
+    }
+    return { sessionToken: token };
+  })
+  .onBeforeHandle(({ sessionToken, set }) => {
+    if (sessionToken == null) {
+      set.status = 401;
+      return { error: "Unauthorized" };
+    }
+  });

--- a/src/routes/users-route.ts
+++ b/src/routes/users-route.ts
@@ -3,7 +3,7 @@ import { jwt } from "@elysiajs/jwt";
 import { eq } from "drizzle-orm";
 import { db } from "../db";
 import { users } from "../db/schema";
-import { getCurrentUser, loginUser, registerUser } from "../services/users-service";
+import { getCurrentUser, loginUser, logoutUser, registerUser } from "../services/users-service";
 
 const JWT_SECRET = process.env.JWT_SECRET || "secret";
 
@@ -42,6 +42,21 @@ const publicUserRoutes = new Elysia({ prefix: "/api/users" })
       const token = auth.slice(7);
       const data = await getCurrentUser(token);
       return { data };
+    } catch {
+      set.status = 401;
+      return { error: "Unauthorized" };
+    }
+  })
+  .delete("/logout", async ({ headers, set }) => {
+    const auth = headers["authorization"];
+    if (!auth?.startsWith("Bearer ")) {
+      set.status = 401;
+      return { error: "Unauthorized" };
+    }
+    try {
+      const token = auth.slice(7);
+      await logoutUser(token);
+      return { data: "ok" };
     } catch {
       set.status = 401;
       return { error: "Unauthorized" };

--- a/src/routes/users-route.ts
+++ b/src/routes/users-route.ts
@@ -3,7 +3,8 @@ import { jwt } from "@elysiajs/jwt";
 import { eq } from "drizzle-orm";
 import { db } from "../db";
 import { users } from "../db/schema";
-import { getCurrentUser, loginUser, logoutUser, registerUser } from "../services/users-service";
+import { sessionTokenAuth } from "../plugins/session-token-auth";
+import { getCurrentUser, loginUser, logoutUser, registerUser, UnauthorizedError } from "../services/users-service";
 
 const JWT_SECRET = process.env.JWT_SECRET || "secret";
 
@@ -31,35 +32,36 @@ const publicUserRoutes = new Elysia({ prefix: "/api/users" })
       }
       throw e;
     }
-  })
-  .get("/current", async ({ headers, set }) => {
-    const auth = headers["authorization"];
-    if (!auth?.startsWith("Bearer ")) {
-      set.status = 401;
-      return { error: "Unauthorized" };
-    }
+  });
+
+const sessionUserRoutes = new Elysia({ prefix: "/api/users" })
+  .use(sessionTokenAuth)
+  .get("/current", async ({ sessionToken, set }) => {
     try {
-      const token = auth.slice(7);
-      const data = await getCurrentUser(token);
+      const data = await getCurrentUser(sessionToken!);
       return { data };
-    } catch {
-      set.status = 401;
-      return { error: "Unauthorized" };
+    } catch (e) {
+      if (e instanceof UnauthorizedError) {
+        set.status = 401;
+        return { error: "Unauthorized" };
+      }
+      console.error("getCurrentUser failed:", e);
+      set.status = 500;
+      return { error: "Internal Server Error" };
     }
   })
-  .delete("/logout", async ({ headers, set }) => {
-    const auth = headers["authorization"];
-    if (!auth?.startsWith("Bearer ")) {
-      set.status = 401;
-      return { error: "Unauthorized" };
-    }
+  .delete("/logout", async ({ sessionToken, set }) => {
     try {
-      const token = auth.slice(7);
-      await logoutUser(token);
+      await logoutUser(sessionToken!);
       return { data: "ok" };
-    } catch {
-      set.status = 401;
-      return { error: "Unauthorized" };
+    } catch (e) {
+      if (e instanceof UnauthorizedError) {
+        set.status = 401;
+        return { error: "Unauthorized" };
+      }
+      console.error("logout failed:", e);
+      set.status = 500;
+      return { error: "Internal Server Error" };
     }
   });
 
@@ -163,4 +165,7 @@ const protectedUserRoutes = new Elysia({ prefix: "/api/users" })
     { params: t.Object({ id: t.String() }) }
   );
 
-export const userRoutes = new Elysia().use(publicUserRoutes).use(protectedUserRoutes);
+export const userRoutes = new Elysia()
+  .use(publicUserRoutes)
+  .use(sessionUserRoutes)
+  .use(protectedUserRoutes);

--- a/src/services/users-service.ts
+++ b/src/services/users-service.ts
@@ -1,8 +1,16 @@
 import { eq } from "drizzle-orm";
+import type { ResultSetHeader } from "mysql2/promise";
 import { db } from "../db";
 import { sessions, users } from "../db/schema";
 
 const LOGIN_ERROR = "Email atau password salah";
+
+export class UnauthorizedError extends Error {
+  constructor(message = "Unauthorized") {
+    super(message);
+    this.name = "UnauthorizedError";
+  }
+}
 
 export type CurrentUserPayload = {
   id: number;
@@ -14,13 +22,13 @@ export type CurrentUserPayload = {
 export async function getCurrentUser(token: string): Promise<CurrentUserPayload> {
   const sessionRows = await db.select().from(sessions).where(eq(sessions.token, token)).limit(1);
   if (sessionRows.length === 0) {
-    throw new Error("Unauthorized");
+    throw new UnauthorizedError();
   }
 
   const userId = sessionRows[0].userId;
   const userRows = await db.select().from(users).where(eq(users.id, userId)).limit(1);
   if (userRows.length === 0) {
-    throw new Error("Unauthorized");
+    throw new UnauthorizedError();
   }
 
   const u = userRows[0];
@@ -66,9 +74,10 @@ export async function registerUser(name: string, email: string, password: string
 }
 
 export async function logoutUser(token: string): Promise<void> {
-  const sessionRows = await db.select().from(sessions).where(eq(sessions.token, token)).limit(1);
-  if (sessionRows.length === 0) {
-    throw new Error("Unauthorized");
+  const result = await db.delete(sessions).where(eq(sessions.token, token));
+  const header = (Array.isArray(result) ? result[0] : result) as ResultSetHeader;
+  const affected = header.affectedRows ?? 0;
+  if (affected === 0) {
+    throw new UnauthorizedError();
   }
-  await db.delete(sessions).where(eq(sessions.token, token));
 }

--- a/src/services/users-service.ts
+++ b/src/services/users-service.ts
@@ -64,3 +64,11 @@ export async function registerUser(name: string, email: string, password: string
   const hashedPassword = await Bun.password.hash(password);
   await db.insert(users).values({ name, email, password: hashedPassword });
 }
+
+export async function logoutUser(token: string): Promise<void> {
+  const sessionRows = await db.select().from(sessions).where(eq(sessions.token, token)).limit(1);
+  if (sessionRows.length === 0) {
+    throw new Error("Unauthorized");
+  }
+  await db.delete(sessions).where(eq(sessions.token, token));
+}


### PR DESCRIPTION
Menambahkan endpoint `DELETE /api/users/logout` dengan header `Authorization: Bearer <token>` (token session di tabel `sessions`). Logout sukses menghapus baris session dan mengembalikan `{ "data": "ok" }`; token tidak valid atau header salah mengembalikan `401` dengan `{ "error": "Unauthorized" }`.

Closes #8
